### PR TITLE
Bugfixes

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Build and Install Wheel
       run: |
         python -m build
-        python -m pip install dist/tcplib-2.0.0-py3-none-any.whl
+        python -m pip install dist/tcplib-2.0.1-py3-none-any.whl
     - name: Test with pytest
       run: |
         pytest

--- a/Documentation/docs.md
+++ b/Documentation/docs.md
@@ -17,7 +17,7 @@ from src.TCPLib.tcp_client import TCPClient
 
 ### `Message(self, size, data, client_id=None)`
 
-Represents a message sent over the network.
+Represents a message sent over the network. A message of size `0` indicates the connection has been terminated.
 
 #### Properties
 - `size`  
@@ -37,7 +37,7 @@ Represents a message sent over the network.
 
 ### `TCPServer(max_clients: int = 0, timeout: int | float | None = None, on_connect: Callable[[TCPClient, str], bool] | None = None):`
 
-A TCP server that listens for and manages multiple TCP/IP client connections.
+A TCP server that listens for and manages multiple TCP client connections.
 
 - If `max_clients` is `0`, the server allows an unlimited number of connections.  
 - If `timeout` is `None`, the server socket has no timeout.  
@@ -105,12 +105,15 @@ A TCP server that listens for and manages multiple TCP/IP client connections.
 - `pop_msg(block: bool = False, timeout: int = None)`  
   Pops the next message from the message queue.  
   - If `block=True`, the method blocks until a message is available.  
-  - If `block=True` and `timeout` is set, the method blocks for `timeout` seconds before returning.  
+  - If `block=True` and `timeout` is set, the method blocks for `timeout` seconds before returning.
+  
   Returns `None` if the queue is empty.
+  A message of size `0` indicates the connection has been terminated.
 
 
 - `get_all_msg()`  
-  Generator for iterating over all messages in the queue. Iteration ends when the queue is empty.
+  Generator for iterating over all messages in the queue. Iteration ends when the queue is empty. 
+  A message of size `0` indicates the connection has been terminated.
 
 
 - `has_messages()`  
@@ -134,7 +137,7 @@ Starts the server and begins listening on the specified address.
 
 ### `TCPClient(self, timeout: int | float | None = None, is_component=False)`
 
-A TCP client that can connect to or host a TCP/IP connection.
+A TCP client that can connect to or host a TCP connection.
 
 The `is_component` argument indicates that TCPClient is a member of another class, specifically a ClientProcessor. This will supress log
 messages in _handle_error(), receive_bytes(), send_bytes(), and disconnect(), since ClientProcessor
@@ -165,15 +168,15 @@ already has its own logging for these functions.
 
 - `from_socket(soc: socket.socket, is_listen_soc=False)`  
   Creates a client from an existing socket. Overrides the socket timeout when `connect()` or `host_single_client()` is called. Returns a new `TCPClient` object.  
-  > ⚠️ If `bind()` or `listen()` is called on the socket before calling `host_single_client()` or `connect()`, both methods will raise an exception.
+  > ⚠️ If `bind()` or `listen()` are called on the socket before calling `TCPClient.host_single_client()` or `TCPClient.connect()`, both methods will raise an exception.
 
 
 - `host_single_client(addr: tuple[str, int], timeout: int = None)`  
-  Hosts a single connection from a remote TCP/IP client. The `timeout` argument defines how long to listen; `None` means wait indefinitely.
+  Hosts a single connection from a remote TCP client. The `timeout` argument defines how long to listen; `None` means wait indefinitely.
 
 
 - `connect(addr: tuple[str, int])`  
-  Connects to a remote TCP/IP host.
+  Connects to a remote TCP host.
 
 
 - `reconnect()`  

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Received message from server: Hello World!
 
 ---
 
-It is also possible for a `TCPClient` object to host a single TCP/IP connection.  
+It is also possible for a `TCPClient` object to host a single TCP connection.  
 Below is an example where `client.py` connects to a host client instead of a server:
 
 #### `host_client.py`
@@ -97,7 +97,16 @@ Install via pip:
 
 ---
 
-### What's New in 2.0.0
+### Bug fixes for 2.0.1
+#### TCPServer
+- When a client disconnects, an empty message is now put in the message queue. This makes it easier for applications 
+to know when a client connection has been closed. I had originally included this behavior in an older development version, and it's
+a mystery why it was removed.
+- Fixed a bug where logging errors were being caught and handled like module errors. I went ahead and evaluated *all* try/except
+blocks and moved excess code out them.
+- Revised some of the logging.
+
+### What's New in Version 2.x
 
 #### General
 
@@ -120,5 +129,3 @@ Install via pip:
   - `local_addr()` always returns the address assigned to the class.
   - `peer_addr()` always returns the address of the connected remote peer.
 - Renamed `send_bytes()` and `receive_bytes()` to `send_raw()` and `receive_raw()`, respectively. The old names were misleading as all data in this library is sent as bytes. The new names for these methods better reflect their intended purpose.
-
----

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 description = "A basic library for implementing a TCP client/server"
 readme = "README.md"
-version='2.0.0'
+version='2.0.1'
 requires-python = ">=3.10"
 license = "MIT"
 classifiers = [

--- a/release_checklist.txt
+++ b/release_checklist.txt
@@ -1,4 +1,5 @@
 BEFORE RELEASE:
+✓ <- leave there for copying and pasting
 
 ✓ Version has been updated in pyproject.toml and python-package.yml
 ✓ Tests are passing

--- a/src/TCPLib/client_processor.py
+++ b/src/TCPLib/client_processor.py
@@ -7,7 +7,6 @@ import logging
 import socket
 import threading
 import queue
-from contextlib import suppress
 from functools import partial
 
 from .message import Message
@@ -18,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 class ClientProcessor:
     """
-    Maintains a single TCP/IP client connection.
+    Maintains a single TCP client connection.
     Pass a callback to on_disconnect to enable certain actions to be taken when stop() is called.
     """
 
@@ -60,17 +59,13 @@ class ClientProcessor:
                     self._total_timeouts += 1
                     if self._max_timeouts is not None:
                         if self._total_timeouts >= self._max_timeouts:
-                            logger.error("Client %s timed out too many times. Disconnecting.", self._client_id)
+                            logger.warning("Client %s timed out too many times. Disconnecting.", self._client_id)
                             self.stop()
                             return
                 continue
             except ConnectionError:
-                # Since this thread runs in the background, it's common to get connection errors during normal
-                # operation since disconnecting can happen outside this thread. For this reason, we only need to log
-                # this exception during debugging
-                if logger.getEffectiveLevel() == logging.DEBUG:
-                    logger.error("Connection error while receiving from %s @ %d", self.remote_addr[0],
-                                     self.remote_addr[1])
+                logger.debug("Receive loop for client #%s on %s @ %d was interrupted", self._client_id, self.remote_addr[0],
+                             self.remote_addr[1])
                 self.stop()
                 return
             except OSError:
@@ -80,7 +75,8 @@ class ClientProcessor:
                 return
 
             if len(data) == 0:
-                logger.info("Received empty data from client %s, stopping", self._client_id)
+                logger.exception("Empty data from %s @ %d, disconnecting", self.remote_addr[0],
+                                 self.remote_addr[1])
                 self.stop()
                 return
 
@@ -199,10 +195,10 @@ class ClientProcessor:
                 except RuntimeError:  # ...unless it already did
                     pass
             self._tcp_client.disconnect()
+            self._msg_q.put(Message(0, bytes(), self._client_id))
             if self._on_disconnect is not None and not suppress_callback:
                 try:
                     self._on_disconnect()
                 except KeyError: # The client may be already disconnected before _on_disconnect() is called. However
                     pass         # we don't care about the KeyError raised by TCPServer.disconnect_client() because we
                                  # we're going to disconnect anyway.
-            logger.debug("Client %s has been stopped.", self._client_id)

--- a/src/TCPLib/tcp_client.py
+++ b/src/TCPLib/tcp_client.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 class TCPClient:
     """
-    A TCP client that can connect to or host a TCP/IP connection.
+    A TCP client that can connect to or host a TCP connection.
     """
 
     def __init__(self, timeout: int | float | None = None, is_component=False):
@@ -61,9 +61,9 @@ class TCPClient:
         try:
             out._peer_addr = soc.getpeername()
             out._local_addr = soc.getsockname()
-            out._last_connected_peer = out._peer_addr
         except OSError:  # Not connected
             return out
+        out._last_connected_peer = out._peer_addr
         out._is_connected = True
         out._is_component = is_component
         return out
@@ -143,7 +143,7 @@ class TCPClient:
 
     def host_single_client(self, addr: tuple[str, int], timeout: int | float | None = None):
         """
-        Hosts a single connection from a remote TCP/IP client. The timeout argument sets how long this
+        Hosts a single connection from a remote TCP client. The timeout argument sets how long this
         method will listen for a connection; 'None' indicates an infinite timeout (default).
         """
         if self._is_connected:
@@ -170,23 +170,26 @@ class TCPClient:
         try:
             self._listen_soc.listen()
             client_soc, client_addr = self._listen_soc.accept()
-            self._soc = client_soc
-            self._peer_addr = client_addr
-            self._last_connected_peer = self._peer_addr
-            self._is_connected = True
-            self._is_host = True
-            logger.info("Accepted connection from %s @ %d", client_addr[0], client_addr[1])
         except TimeoutError as e:
             self._handle_error(e, "Timed out while attempting to connect to remote client")
+            return
         except ConnectionError as e:
             self._handle_error(e, "Failed to establish connection to remote client")
+            return
+
+        self._soc = client_soc
+        self._peer_addr = client_addr
+        self._last_connected_peer = self._peer_addr
+        self._is_connected = True
+        self._is_host = True
+        logger.info("Accepted connection from %s @ %d", client_addr[0], client_addr[1])
         self._listen_soc.close()
         self._listen_soc = None
         return
 
     def connect(self, addr: tuple[str, int]):
         """
-        Connects to a remote TCP/IP host.
+        Connects to a remote TCP host.
         """
         if self._is_connected:
             return
@@ -208,18 +211,23 @@ class TCPClient:
         logger.info("Attempting to connect to %s @ %d", self._last_connected_peer[0], self._last_connected_peer[1])
         try:
             self._soc.connect(self._peer_addr)
-            self._is_connected = True
-            self._is_host = False
-            self._local_addr = self._soc.getsockname()
-            logger.info("Successfully connected to %s @ %d", self._last_connected_peer[0], self._last_connected_peer[1])
         except TimeoutError as e:
             self._handle_error(e, "Timed out while attempting to connect to %s @ %d", self._last_connected_peer[0], self._last_connected_peer[1])
+            return
         except ConnectionError as e:
             self._handle_error(e, "Could not connect to %s @ %d", self._last_connected_peer[0], self._last_connected_peer[1])
+            return
         except socket.gaierror as e:
             self._handle_error(e, "Could not resolve address %s @ %d", self._last_connected_peer[0], self._last_connected_peer[1])
+            return
         except OSError as e:
             self._handle_error(e, "OSError while connecting to %s @ %d", self._last_connected_peer[0], self._last_connected_peer[1])
+            return
+
+        self._is_connected = True
+        self._is_host = False
+        self._local_addr = self._soc.getsockname()
+        logger.info("Successfully connected to %s @ %d", self._last_connected_peer[0], self._last_connected_peer[1])
 
     def reconnect(self):
         """
@@ -251,7 +259,6 @@ class TCPClient:
             raise ConnectionError("Client is not connected to a host")
         try:
             self._soc.sendall(data)
-            return True
         except AttributeError: # Socket was closed from another thread
             self._clean_up()
             return False
@@ -261,8 +268,11 @@ class TCPClient:
             raise e
         except ConnectionError as e:
             self._handle_error(e, "Connection error while sending to %s @ %d", self._last_connected_peer[0], self._last_connected_peer[1])
+            return
         except OSError as e:
             self._handle_error(e, "OSError while sending to %s @ %d", self._last_connected_peer[0], self._last_connected_peer[1])
+            return
+        return True
 
     def send(self, data: bytes) -> bool:
         """
@@ -282,7 +292,6 @@ class TCPClient:
             raise ValueError("'size' argument must be a non-zero, positive integer")
         try:
             data = self._soc.recv(size)
-            return data
         except AttributeError: # Socket was closed from another thread
             self._clean_up()
             return bytes(0)
@@ -292,11 +301,15 @@ class TCPClient:
             raise e
         except ConnectionError as e:
             self._handle_error(e, "Connection error while receiving from %s @ %d", self._last_connected_peer[0], self._last_connected_peer[1])
+            return
         except OSError as e:
             self._handle_error(e, "OSError while receiving from %s @ %d", self._last_connected_peer[0], self._last_connected_peer[1])
+            return
+
+        return data
 
 
-    def iter_receive(self, buff_size: int = 4096, suppress_logs=False) -> Generator:
+    def iter_receive(self, buff_size: int = 4096) -> Generator:
         """
         Generator that yields chunks of a message. First yield is the total message size.
         This method expects a 4 bytes size header to be attached.
@@ -339,7 +352,7 @@ class TCPClient:
             raise ConnectionError("Client is not connected to a host")
         if buff_size <= 0:
             raise ValueError("'buff_size' argument must be a non-zero, positive integer")
-        gen = self.iter_receive(buff_size, suppress_logs=suppress_logs)
+        gen = self.iter_receive(buff_size)
         if not gen:
             return bytearray()
         try:

--- a/src/TCPLib/tcp_server.py
+++ b/src/TCPLib/tcp_server.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 class TCPServer:
     """
-    Creates, maintains, and transmits data to multiple TCP/IP connections.
+    Creates, maintains, and transmits data to multiple TCP connections.
 
     If `max_clients` is 0, the server allows an unlimited number of connections.
     If `timeout` is None, the server socket has no timeout.
@@ -79,12 +79,6 @@ class TCPServer:
             client_soc, client_addr = None, None
             try:
                 client_soc, client_addr = self._soc.accept()
-                if self.is_full:
-                    logger.warning("%s @ %d was denied connection due to server being full",
-                                   client_addr[0], client_addr[1])
-                    client_soc.close()
-                    continue
-                self._start_client_proc(self._generate_client_id(), client_soc)
             except TimeoutError:
                 if client_addr is None:
                     logger.warning("New connection timed out before connection could be accepted")
@@ -107,6 +101,13 @@ class TCPServer:
                     logger.error("OSError raised while listening for connections")
                 self.stop()
                 break
+
+            if self.is_full:
+                logger.warning("%s @ %d was denied connection due to server being full",
+                               client_addr[0], client_addr[1])
+                client_soc.close()
+                continue
+            self._start_client_proc(self._generate_client_id(), client_soc)
 
         logger.debug("Server is no longer listening for messages")
 

--- a/tests/dummy_soc.py
+++ b/tests/dummy_soc.py
@@ -2,7 +2,6 @@ import logging
 import threading
 import time
 import socket
-from TCPLib.tcp_server import TCPServer
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_ClientProcessor.py
+++ b/tests/test_ClientProcessor.py
@@ -119,7 +119,7 @@ class TestClientProcessor:
                                              "timed out too many times. Disconnecting.",
                                              caplog,
                                              wait_time=1,
-                                             log_level=logging.ERROR)
+                                             log_level=logging.WARNING)
 
     def test_recv_loop_too_many_timeouts(self, client_processor, caplog):
         add_file_handler(logger,
@@ -134,7 +134,7 @@ class TestClientProcessor:
                                              "timed out too many times. Disconnecting.",
                                              caplog,
                                              wait_time=5,
-                                             log_level=logging.ERROR)
+                                             log_level=logging.WARNING)
 
         assert client_processor[0]._total_timeouts == 4
 
@@ -147,7 +147,7 @@ class TestClientProcessor:
                          "test_recv_loop_raise_connection_error-filehandler")
 
         self.assert_message_logged_recv_loop(error_client_processor,
-                                             'Connection error while receiving from',
+                                             'Receive loop for client',
                                              caplog,
                                              wait_time=2)
 
@@ -219,18 +219,3 @@ class TestClientProcessor:
         processor.start()  # Should not create new thread
         assert processor._thread is first_thread
         processor.stop()
-
-    def test_stop_called_twice(self, client_processor, caplog):
-        add_file_handler(logger,
-                         os.path.join(log_folder, "test_stop_called_twice.log"),
-                         logging.DEBUG, "test_stop_called_twice-filehandler")
-        processor = client_processor[0]
-
-        with caplog.at_level(logging.DEBUG):
-            processor.start()
-            processor.stop()
-            while processor.is_running:
-                pass
-            processor.stop()
-
-        assert len([record for record in caplog.records if "has been stopped." in record.msg]) == 1


### PR DESCRIPTION
### Bug fixes for 2.0.1
#### TCPServer
- When a client disconnects, an empty message is now put in the message queue. This makes it easier for applications 
to know when a client connection has been closed. I had originally included this behavior in an older development version, and it's
a mystery why it was removed.
- Fixed a bug where logging errors were being caught and handled like module errors. I went ahead and evaluated *all* try/except
blocks and moved excess code out them.
- Revised some of the logging.
